### PR TITLE
Add python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Tools/piksel/_version.py

--- a/Tools/piksel/__init__.py
+++ b/Tools/piksel/__init__.py
@@ -1,0 +1,5 @@
+from csdr._version import __version__, __version_tuple__  # noqa F401
+
+
+def get_version() -> str:
+    return __version__

--- a/Tools/piksel/utils.py
+++ b/Tools/piksel/utils.py
@@ -1,0 +1,11 @@
+def patch_usgs_landsat(url: str) -> str:
+    """
+    Patch the USGS Landsat URL to use s3:// instead of https://.
+
+    Args:
+        url (str): The original URL.
+
+    Returns:
+        str: The patched URL.
+    """
+    return url.replace("https://landsatlook.usgs.gov/data", "s3://usgs-landsat")

--- a/Tools/pyproject.toml
+++ b/Tools/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "piksel"
+dynamic = ["version"]
+description = "Tools to support the BIG Piksel project"
+readme = "../README.md"
+requires-python = ">=3.11"
+license = { file = "../LICENSE" }
+authors = [
+    { name = "Alex Leith", email = "alex@auspatious.com" },
+]
+keywords = ["data"]
+
+dependencies = [
+    "hatchling==1.27.0",
+    "hatch-vcs==0.4.0",
+]
+
+[project.optional-dependencies]
+dev = []
+
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+root = ".."
+fallback-version = "0.9.0"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "piksel/_version.py"
+root = ".."
+
+[tool.hatch.build]
+include = ["piksel/**.py"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["piksel"]
+
+[tool.ruff]
+ignore = ["E501"]
+fix = true
+
+[tool.ruff.lint]
+extend-select = ["ANN", "I", "RUF", "UP"]
+
+[tool.mypy]
+ignore_missing_imports = true
+strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 name = "piksel"
 dynamic = ["version"]
 description = "Tools to support the BIG Piksel project"
-readme = "../README.md"
+readme = "README.md"
 requires-python = ">=3.11"
-license = { file = "../LICENSE" }
+license = { file = "LICENSE" }
 authors = [
     { name = "Alex Leith", email = "alex@auspatious.com" },
 ]
@@ -12,7 +12,7 @@ keywords = ["data"]
 
 dependencies = [
     "hatchling==1.27.0",
-    "hatch-vcs==0.4.0",
+    "hatch-vcs==0.5.0",
 ]
 
 [project.optional-dependencies]
@@ -25,17 +25,16 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 root = ".."
-fallback-version = "0.9.0"
 
 [tool.hatch.build.hooks.vcs]
-version-file = "piksel/_version.py"
+version-file = "Tools/piksel/_version.py"
 root = ".."
 
 [tool.hatch.build]
-include = ["piksel/**.py"]
+include = ["Tools/piksel/**.py"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["piksel"]
+packages = ["Tools/piksel"]
 
 [tool.ruff]
 ignore = ["E501"]


### PR DESCRIPTION
Add a super basic Python package.

Now we can do `from piksel.utils import patch_usgs_landsat` and won't need to worry about relative imports.

Once merged into main, we can include this into the Jupyter build :-) 